### PR TITLE
API: Make initialisms more consistent 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [chenkaiC4](https://github.com/chenkaiC4) - *Fix GolangCI Linter*
 * [Woodrow Douglass](https://github.com/wdouglass) *RTCP, RTP improvements, G.722 support, Bugfixes*
 * [Michael MacDonald](https://github.com/mjmac)
+* [Max Hawkins](https://github.com/maxhawkins)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/jsep.go
+++ b/jsep.go
@@ -17,8 +17,8 @@ const (
 	AttrKeyConnectionSetup = "setup"
 	AttrKeyMID             = "mid"
 	AttrKeyICELite         = "ice-lite"
-	AttrKeyRtcpMux         = "rtcp-mux"
-	AttrKeyRtcpRsize       = "rtcp-rsize"
+	AttrKeyRTCPMux         = "rtcp-mux"
+	AttrKeyRTCPRsize       = "rtcp-rsize"
 )
 
 // Constants for semantic tokens used in JSEP

--- a/jsep.go
+++ b/jsep.go
@@ -11,8 +11,8 @@ import (
 const (
 	AttrKeyIdentity        = "identity"
 	AttrKeyGroup           = "group"
-	AttrKeySsrc            = "ssrc"
-	AttrKeySsrcGroup       = "ssrc-group"
+	AttrKeySSRC            = "ssrc"
+	AttrKeySSRCGroup       = "ssrc-group"
 	AttrKeyMsidSemantic    = "msid-semantic"
 	AttrKeyConnectionSetup = "setup"
 	AttrKeyMID             = "mid"


### PR DESCRIPTION
Change capitalization to be consistent with other uses in the project, and to match the Go convention of capitalizing initialisms:

https://github.com/golang/go/wiki/CodeReviewComments#initialisms