### PR TITLE
[]byte API

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -35,7 +35,8 @@ import (
 //    b=* (zero or more bandwidth information lines)
 //    k=* (encryption key)
 //    a=* (zero or more media attribute lines)
-func (s *SessionDescription) Marshal() (raw string) {
+func (s *SessionDescription) Marshal() ([]byte, error) {
+	var raw string
 	raw += keyValueBuild("v=", s.Version.String())
 	raw += keyValueBuild("o=", s.Origin.String())
 	raw += keyValueBuild("s=", s.SessionName.String())
@@ -114,5 +115,5 @@ func (s *SessionDescription) Marshal() (raw string) {
 		}
 	}
 
-	return raw
+	return []byte(raw), nil
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -158,8 +158,11 @@ func TestMarshalCanonical(t *testing.T) {
 		},
 	}
 
-	actual := sd.Marshal()
-	if actual != CanonicalMarshalSDP {
+	actual, err := sd.Marshal()
+	if got, want := err, error(nil); got != want {
+		t.Fatalf("Marshal(): err=%v, want %v", got, want)
+	}
+	if string(actual) != CanonicalMarshalSDP {
 		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", CanonicalMarshalSDP, actual)
 	}
 }

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -2,6 +2,7 @@ package sdp
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -81,10 +82,10 @@ import (
 // |   s15  |    |    14 |    |     | 15 |     |   |    | 12 |   |   |     |   |   |    |   |    |
 // |   s16  |    |    14 |    |     |    |  15 |   |    | 12 |   |   |     |   |   |    |   |    |
 // +--------+----+-------+----+-----+----+-----+---+----+----+---+---+-----+---+---+----+---+----+
-func (s *SessionDescription) Unmarshal(value string) error {
+func (s *SessionDescription) Unmarshal(value []byte) error {
 	l := &lexer{
 		desc:  s,
-		input: bufio.NewReader(strings.NewReader(value)),
+		input: bufio.NewReader(bytes.NewReader(value)),
 	}
 	for state := s1; state != nil; {
 		var err error

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -186,7 +186,7 @@ func TestRoundTrip(t *testing.T) {
 	} {
 		sd := &SessionDescription{}
 
-		err := sd.Unmarshal(test.SDP)
+		err := sd.Unmarshal([]byte(test.SDP))
 		if got, want := err, error(nil); got != want {
 			t.Fatalf("Unmarshal(%s): err=%v, want %v", test.Name, got, want)
 		}
@@ -203,7 +203,7 @@ func TestRoundTrip(t *testing.T) {
 
 func TestUnmarshalRepeatTimes(t *testing.T) {
 	sd := &SessionDescription{}
-	if err := sd.Unmarshal(RepeatTimesSDP); err != nil {
+	if err := sd.Unmarshal([]byte(RepeatTimesSDP)); err != nil {
 		t.Errorf("error: %v", err)
 	}
 
@@ -218,7 +218,7 @@ func TestUnmarshalRepeatTimes(t *testing.T) {
 
 func TestUnmarshalTimeZones(t *testing.T) {
 	sd := &SessionDescription{}
-	if err := sd.Unmarshal(TimeZonesSDP); err != nil {
+	if err := sd.Unmarshal([]byte(TimeZonesSDP)); err != nil {
 		t.Errorf("error: %v", err)
 	}
 

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -191,8 +191,11 @@ func TestRoundTrip(t *testing.T) {
 			t.Fatalf("Unmarshal(%s): err=%v, want %v", test.Name, got, want)
 		}
 
-		data := sd.Marshal()
-		if got, want := data, test.SDP; got != want {
+		actual, err := sd.Marshal()
+		if got, want := err, error(nil); got != want {
+			t.Fatalf("Marshal(): err=%v, want %v", got, want)
+		}
+		if got, want := string(actual), test.SDP; got != want {
 			t.Fatalf("Marshal(%s) = %q, want %q", test.Name, got, want)
 		}
 	}
@@ -204,8 +207,11 @@ func TestUnmarshalRepeatTimes(t *testing.T) {
 		t.Errorf("error: %v", err)
 	}
 
-	actual := sd.Marshal()
-	if actual != RepeatTimesSDPExpected {
+	actual, err := sd.Marshal()
+	if got, want := err, error(nil); got != want {
+		t.Fatalf("Marshal(): err=%v, want %v", got, want)
+	}
+	if string(actual) != RepeatTimesSDPExpected {
 		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", RepeatTimesSDPExpected, actual)
 	}
 }
@@ -216,8 +222,11 @@ func TestUnmarshalTimeZones(t *testing.T) {
 		t.Errorf("error: %v", err)
 	}
 
-	actual := sd.Marshal()
-	if actual != TimeZonesSDPExpected {
+	actual, err := sd.Marshal()
+	if got, want := err, error(nil); got != want {
+		t.Fatalf("Marshal(): err=%v, want %v", got, want)
+	}
+	if string(actual) != TimeZonesSDPExpected {
 		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", TimeZonesSDPExpected, actual)
 	}
 }

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -110,75 +110,91 @@ const (
 		"a=rtpmap:99 h263-1998/90000\r\n"
 )
 
-func TestUnmarshalSessionInformation(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(SessionInformationSDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
+func TestRoundTrip(t *testing.T) {
+	for _, test := range []struct {
+		Name string
+		SDP  string
+	}{
+		{
+			Name: "SessionInformation",
+			SDP:  SessionInformationSDP,
+		},
+		{
+			Name: "URI",
+			SDP:  URISDP,
+		},
+		{
+			Name: "EmailAddress",
+			SDP:  string(EmailAddressSDP),
+		},
+		{
+			Name: "PhoneNumber",
+			SDP:  PhoneNumberSDP,
+		},
+		{
+			Name: "SessionConnectionInformation",
+			SDP:  SessionConnectionInformationSDP,
+		},
+		{
+			Name: "SessionConnectionInformation",
+			SDP:  SessionConnectionInformationSDP,
+		},
+		{
+			Name: "SessionBandwidth",
+			SDP:  SessionBandwidthSDP,
+		},
+		{
+			Name: "SessionEncryptionKey",
+			SDP:  SessionEncryptionKeySDP,
+		},
+		{
+			Name: "SessionAttributes",
+			SDP:  SessionAttributesSDP,
+		},
+		{
+			Name: "MediaName",
+			SDP:  MediaNameSDP,
+		},
+		{
+			Name: "MediaTitle",
+			SDP:  MediaTitleSDP,
+		},
+		{
+			Name: "MediaConnectionInformation",
+			SDP:  MediaConnectionInformationSDP,
+		},
+		{
+			Name: "MediaConnectionInformation",
+			SDP:  MediaConnectionInformationSDP,
+		},
+		{
+			Name: "MediaBandwidth",
+			SDP:  MediaBandwidthSDP,
+		},
+		{
+			Name: "MediaEncryptionKey",
+			SDP:  MediaEncryptionKeySDP,
+		},
+		{
+			Name: "MediaAttributes",
+			SDP:  MediaAttributesSDP,
+		},
+		{
+			Name: "CanonicalUnmarshal",
+			SDP:  CanonicalUnmarshalSDP,
+		},
+	} {
+		sd := &SessionDescription{}
 
-	actual := sd.Marshal()
-	if actual != SessionInformationSDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", SessionInformationSDP, actual)
-	}
-}
+		err := sd.Unmarshal(test.SDP)
+		if got, want := err, error(nil); got != want {
+			t.Fatalf("Unmarshal(%s): err=%v, want %v", test.Name, got, want)
+		}
 
-func TestUnmarshalURI(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(URISDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
-
-	actual := sd.Marshal()
-	if actual != URISDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", URISDP, actual)
-	}
-}
-
-func TestUnmarshalEmailAddress(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(EmailAddressSDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
-
-	actual := sd.Marshal()
-	if actual != EmailAddressSDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", EmailAddressSDP, actual)
-	}
-}
-
-func TestUnmarshalPhoneNumber(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(PhoneNumberSDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
-
-	actual := sd.Marshal()
-	if actual != PhoneNumberSDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", PhoneNumberSDP, actual)
-	}
-}
-
-func TestUnmarshalSessionConnectionInformation(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(SessionConnectionInformationSDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
-
-	actual := sd.Marshal()
-	if actual != SessionConnectionInformationSDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", SessionConnectionInformationSDP, actual)
-	}
-}
-
-func TestUnmarshalSessionBandwidth(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(SessionBandwidthSDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
-
-	actual := sd.Marshal()
-	if actual != SessionBandwidthSDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", SessionBandwidthSDP, actual)
+		data := sd.Marshal()
+		if got, want := data, test.SDP; got != want {
+			t.Fatalf("Marshal(%s) = %q, want %q", test.Name, got, want)
+		}
 	}
 }
 
@@ -203,113 +219,5 @@ func TestUnmarshalTimeZones(t *testing.T) {
 	actual := sd.Marshal()
 	if actual != TimeZonesSDPExpected {
 		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", TimeZonesSDPExpected, actual)
-	}
-}
-
-func TestUnmarshalSessionEncryptionKey(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(SessionEncryptionKeySDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
-
-	actual := sd.Marshal()
-	if actual != SessionEncryptionKeySDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", SessionEncryptionKeySDP, actual)
-	}
-}
-
-func TestUnmarshalSessionAttributes(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(SessionAttributesSDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
-
-	actual := sd.Marshal()
-	if actual != SessionAttributesSDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", SessionAttributesSDP, actual)
-	}
-}
-
-func TestUnmarshalMediaName(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(MediaNameSDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
-
-	actual := sd.Marshal()
-	if actual != MediaNameSDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", MediaNameSDP, actual)
-	}
-}
-
-func TestUnmarshalMediaTitle(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(MediaTitleSDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
-
-	actual := sd.Marshal()
-	if actual != MediaTitleSDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", MediaTitleSDP, actual)
-	}
-}
-
-func TestUnmarshalMediaConnectionInformation(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(MediaConnectionInformationSDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
-
-	actual := sd.Marshal()
-	if actual != MediaConnectionInformationSDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", MediaConnectionInformationSDP, actual)
-	}
-}
-
-func TestUnmarshalMediaBandwidth(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(MediaBandwidthSDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
-
-	actual := sd.Marshal()
-	if actual != MediaBandwidthSDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", MediaBandwidthSDP, actual)
-	}
-}
-
-func TestUnmarshalMediaEncryptionKey(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(MediaEncryptionKeySDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
-
-	actual := sd.Marshal()
-	if actual != MediaEncryptionKeySDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", MediaEncryptionKeySDP, actual)
-	}
-}
-
-func TestUnmarshalMediaAttributes(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(MediaAttributesSDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
-
-	actual := sd.Marshal()
-	if actual != MediaAttributesSDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", MediaAttributesSDP, actual)
-	}
-}
-
-func TestUnmarshalCanonical(t *testing.T) {
-	sd := &SessionDescription{}
-	if err := sd.Unmarshal(CanonicalUnmarshalSDP); err != nil {
-		t.Errorf("error: %v", err)
-	}
-
-	actual := sd.Marshal()
-	if actual != CanonicalUnmarshalSDP {
-		t.Errorf("error:\n\nEXPECTED:\n%v\nACTUAL:\n%v", CanonicalUnmarshalSDP, actual)
 	}
 }


### PR DESCRIPTION
It seems more consistent to use `[]byte` for the Marshal and Unmarshal functions to match the stdlib.

There might also be some [performance advantages](https://talks.godoc.org/github.com/davecheney/qconsf-2017/high-performance-go.slide#44) to using []byte.